### PR TITLE
feat(autoware_adapi_v1_msgs): add motion api message

### DIFF
--- a/autoware_adapi_v1_msgs/CMakeLists.txt
+++ b/autoware_adapi_v1_msgs/CMakeLists.txt
@@ -16,6 +16,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   routing/srv/ClearRoute.srv
   routing/srv/SetRoute.srv
   routing/srv/SetRoutePoints.srv
+  motion/msg/MotionState.msg
+  motion/srv/AcceptStart.srv
   planning/msg/SteeringFactor.msg
   planning/msg/SteeringFactorArray.msg
   DEPENDENCIES

--- a/autoware_adapi_v1_msgs/motion/msg/MotionState.msg
+++ b/autoware_adapi_v1_msgs/motion/msg/MotionState.msg
@@ -1,0 +1,7 @@
+uint16 UNKNOWN = 0
+uint16 STOPPED = 1
+uint16 STARTING = 2
+uint16 MOVING = 3
+
+builtin_interfaces/Time stamp
+uint16 state

--- a/autoware_adapi_v1_msgs/motion/srv/AcceptStart.srv
+++ b/autoware_adapi_v1_msgs/motion/srv/AcceptStart.srv
@@ -1,0 +1,3 @@
+---
+uint16 ERROR_NOT_STARTING = 1
+autoware_adapi_v1_msgs/ResponseStatus status


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Add the messages for motion API.
https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/ad-api/list/api/motion/

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
