### PR TITLE
feat(autoware_adapi_v1_msgs): remove planning factor type

### DIFF
--- a/autoware_adapi_v1_msgs/planning/msg/SteeringFactor.msg
+++ b/autoware_adapi_v1_msgs/planning/msg/SteeringFactor.msg
@@ -19,23 +19,3 @@ string behavior
 string sequence
 string detail
 autoware_adapi_v1_msgs/CooperationStatus[<=1] cooperation
-
-
-
-# deprecated constants for type
-uint16 INTERSECTION = 1
-uint16 LANE_CHANGE = 2
-uint16 AVOIDANCE_PATH_CHANGE = 3
-uint16 AVOIDANCE_PATH_RETURN = 4
-uint16 STATION = 5
-uint16 PULL_OUT = 6 # Deprecated. Use START_PLANNER.
-uint16 START_PLANNER = 6
-uint16 PULL_OVER = 7  # Deprecated. Use GOAL_PLANNER.
-uint16 GOAL_PLANNER = 7
-uint16 EMERGENCY_OPERATION = 8
-
-# deprecated constants for status
-uint16 TRYING = 2
-
-# deprecated variables
-uint16 type

--- a/autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
+++ b/autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
@@ -13,27 +13,3 @@ string behavior
 string sequence
 string detail
 autoware_adapi_v1_msgs/CooperationStatus[<=1] cooperation
-
-
-
-# deprecated constants for type
-uint16 SURROUNDING_OBSTACLE = 1
-uint16 ROUTE_OBSTACLE = 2
-uint16 INTERSECTION = 3
-uint16 CROSSWALK = 4
-uint16 REAR_CHECK = 5
-uint16 USER_DEFINED_DETECTION_AREA = 6
-uint16 NO_STOPPING_AREA = 7
-uint16 STOP_SIGN = 8
-uint16 TRAFFIC_SIGNAL = 9
-uint16 V2I_GATE_CONTROL_ENTER = 10
-uint16 V2I_GATE_CONTROL_LEAVE = 11
-uint16 MERGE = 12
-uint16 SIDEWALK = 13
-uint16 LANE_CHANGE = 14
-uint16 AVOIDANCE = 15
-uint16 EMERGENCY_STOP_OPERATION = 16
-uint16 NO_DRIVABLE_LANE = 17
-
-# deprecated variables
-uint16 type


### PR DESCRIPTION
## Description

Remove the `type` field used in the proposed message (this is before the release).
The latest proposal uses `behavior` field instead.

## Tests performed

See https://github.com/autowarefoundation/autoware.universe/pull/5793.

## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
