### PR TITLE
build: set package versions to the package.xml files

### DIFF
--- a/autoware_adapi_v1_msgs/package.xml
+++ b/autoware_adapi_v1_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_adapi_v1_msgs</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>The Autoware ADAPI interfaces</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>

--- a/autoware_adapi_v1_msgs/package.xml
+++ b/autoware_adapi_v1_msgs/package.xml
@@ -2,9 +2,10 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_adapi_v1_msgs</name>
-  <version>0.0.0</version>
+  <version>1.1.0</version>
   <description>The autoware_adapi_v1_msgs package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
+  <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/autoware_adapi_v1_msgs/package.xml
+++ b/autoware_adapi_v1_msgs/package.xml
@@ -11,15 +11,20 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <build_depend>rosidl_default_generators</build_depend>
-
-  <depend>builtin_interfaces</depend>
-  <depend>geographic_msgs</depend>
-  <depend>geometry_msgs</depend>
-  <depend>shape_msgs</depend>
-  <depend>std_msgs</depend>
-  <depend>unique_identifier_msgs</depend>
+  <build_depend>builtin_interfaces</build_depend>
+  <build_depend>geographic_msgs</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>shape_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>unique_identifier_msgs</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>builtin_interfaces</exec_depend>
+  <exec_depend>geographic_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>shape_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>unique_identifier_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/autoware_adapi_v1_msgs/package.xml
+++ b/autoware_adapi_v1_msgs/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>autoware_adapi_v1_msgs</name>
   <version>1.1.0</version>
-  <description>The autoware_adapi_v1_msgs package</description>
+  <description>The Autoware ADAPI interfaces</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>

--- a/autoware_adapi_v1_msgs/package.xml
+++ b/autoware_adapi_v1_msgs/package.xml
@@ -10,18 +10,18 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>builtin_interfaces</build_depend>
   <build_depend>geographic_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>shape_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>unique_identifier_msgs</build_depend>
 
-  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   <exec_depend>geographic_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>shape_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>unique_identifier_msgs</exec_depend>

--- a/autoware_adapi_v1_msgs/package.xml
+++ b/autoware_adapi_v1_msgs/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>autoware_adapi_v1_msgs</name>
   <version>1.2.0</version>
-  <description>The Autoware ADAPI interfaces</description>
+  <description>The Autoware AD API interfaces</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>

--- a/autoware_adapi_v1_msgs/package.xml
+++ b/autoware_adapi_v1_msgs/package.xml
@@ -10,21 +10,16 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>builtin_interfaces</build_depend>
-  <build_depend>geographic_msgs</build_depend>
-  <build_depend>geometry_msgs</build_depend>
   <build_depend>rosidl_default_generators</build_depend>
-  <build_depend>shape_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_depend>unique_identifier_msgs</build_depend>
 
-  <exec_depend>builtin_interfaces</exec_depend>
-  <exec_depend>geographic_msgs</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
+  <depend>builtin_interfaces</depend>
+  <depend>geographic_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>shape_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
+
   <exec_depend>rosidl_default_runtime</exec_depend>
-  <exec_depend>shape_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>unique_identifier_msgs</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/autoware_adapi_version_msgs/package.xml
+++ b/autoware_adapi_version_msgs/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>autoware_adapi_version_msgs</name>
   <version>1.1.0</version>
-  <description>The Autoware ADAPI version interfaces</description>
+  <description>The Autoware AD API version interfaces</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>

--- a/autoware_adapi_version_msgs/package.xml
+++ b/autoware_adapi_version_msgs/package.xml
@@ -2,9 +2,10 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_adapi_version_msgs</name>
-  <version>0.0.0</version>
+  <version>1.1.0</version>
   <description>The autoware_adapi_version_msgs package</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
+  <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/autoware_adapi_version_msgs/package.xml
+++ b/autoware_adapi_version_msgs/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_adapi_version_msgs</name>
-  <version>1.1.0</version>
+  <version>1.2.0</version>
   <description>The Autoware AD API version interfaces</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>

--- a/autoware_adapi_version_msgs/package.xml
+++ b/autoware_adapi_version_msgs/package.xml
@@ -3,7 +3,7 @@
 <package format="3">
   <name>autoware_adapi_version_msgs</name>
   <version>1.1.0</version>
-  <description>The autoware_adapi_version_msgs package</description>
+  <description>The Autoware ADAPI version interfaces</description>
   <maintainer email="isamu.takagi@tier4.jp">Takagi, Isamu</maintainer>
   <maintainer email="yutaka.kondo@tier4.jp">Yutaka Kondo</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
## Description

This PR has set the package versions to 1.1.0. Since the v1.0 tag has already been struck, the minor version has been updated to 1.2.0.

This change is a first step to release these packages from the official ROS build farm in the future.


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
