### PR TITLE
feat(autoware_adapi_v1_msgs): remove energy status

### DIFF
--- a/autoware_adapi_v1_msgs/vehicle/msg/VehicleStatus.msg
+++ b/autoware_adapi_v1_msgs/vehicle/msg/VehicleStatus.msg
@@ -3,4 +3,3 @@ autoware_adapi_v1_msgs/Gear gear
 autoware_adapi_v1_msgs/TurnIndicators turn_indicators
 autoware_adapi_v1_msgs/HazardLights hazard_lights
 float64 steering_tire_angle
-float32 energy_percentage  # Battery percentage or fuel percentage, it will depends on the vehicle.


### PR DESCRIPTION
## Description

Remove energy status because its internal interface has not been defined.
I'll release this for now and consider energy later.
This PR must merge after https://github.com/autowarefoundation/autoware.universe/pull/7464

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
