### PR TITLE
fix(planning): add boolean field so that it can distinguish if the ego will stop

### DIFF
--- a/autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
+++ b/autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
@@ -13,3 +13,4 @@ string behavior
 string sequence
 string detail
 autoware_adapi_v1_msgs/CooperationStatus[<=1] cooperation
+bool stop_factor


### PR DESCRIPTION
## Description

Add boolean field so that it can distinguish if the ego will stop.

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- [x] PASS CI

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Nothing.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
