### PR TITLE
feat: drop route following check option

### DIFF
--- a/autoware_adapi_v1_msgs/routing/msg/RouteOption.msg
+++ b/autoware_adapi_v1_msgs/routing/msg/RouteOption.msg
@@ -2,4 +2,3 @@
 # https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/ad-api/features/routing/
 
 bool allow_goal_modification
-bool allow_while_using_route


### PR DESCRIPTION
## Description

Drop allow_using_while_route that is added by https://github.com/autowarefoundation/autoware_adapi_msgs/pull/61.
See https://github.com/autowarefoundation/autoware-documentation/pull/633  for the reason.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

Remove allow_using_while_route (not released yet)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
