### PR TITLE
feat(autoware_adapit_v1_msgs): add redundancy swicher reset service

### DIFF
--- a/autoware_adapi_v1_msgs/CMakeLists.txt
+++ b/autoware_adapi_v1_msgs/CMakeLists.txt
@@ -46,6 +46,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   system/msg/DiagLinkStruct.msg
   system/msg/DiagNodeStruct.msg
   system/msg/DiagNodeStatus.msg
+  system/srv/RedundancySwitcherReset.srv
   vehicle/msg/DoorCommand.msg
   vehicle/msg/DoorLayout.msg
   vehicle/msg/DoorStatus.msg

--- a/autoware_adapi_v1_msgs/system/srv/RedundancySwitcherReset.srv
+++ b/autoware_adapi_v1_msgs/system/srv/RedundancySwitcherReset.srv
@@ -1,0 +1,2 @@
+---
+autoware_adapi_v1_msgs/ResponseStatus status


### PR DESCRIPTION
## Description
This PR adds redundancy switcher reset service to autoware_adapi_v1_msgs directory.
It is used to call to redundancy_switcher_interface in a redundant configuration.
redundancy_switcher_interface convert it to udp pakcets and send redundancy switcher. Thereby, redundancy_switcher resets its own state variable.

## How was this PR tested?


## Notes for reviewers
This service is intended to reset redundancy switchers from MOT and Rviz.

[redundancy block diagrams](https://app.diagrams.net/#G1NNfbmIIAa4TqzvGXTtKmxjdHmDcOiDx2#%7B%22pageId%22%3A%22vGw_7d2tEutVj_XndojI%22%7D)

Node Description

redundancy_switcher_interface: convert udp packets sent from redundancy switcher to ros2 topic, and ros2 topic to udp pakcets.


## Effects on system behavior

None.
