### PR TITLE
fix: wrongly updated version 1.7.0

### DIFF
--- a/autoware_adapi_v1_msgs/CHANGELOG.rst
+++ b/autoware_adapi_v1_msgs/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_adapi_v1_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.7.0 (2025-02-18)
+------------------
 * feat: drop route following check option (`#71 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/71>`_)
 * fix(autoware_adapi_msgs): fix links to issues in CHANGELOG.rst files (`#72 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/72>`_)
 * feat(planning): add new planning behavior (adaptive-cruise) (`#67 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/67>`_)

--- a/autoware_adapi_version_msgs/CHANGELOG.rst
+++ b/autoware_adapi_version_msgs/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package autoware_adapi_version_msgs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.7.0 (2025-02-18)
+------------------
 * fix(autoware_adapi_msgs): fix links to issues in CHANGELOG.rst files (`#72 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/72>`_)
 * feat: update v1.6.0 (`#63 <https://github.com/autowarefoundation/autoware_adapi_msgs/issues/63>`_)
 * Contributors: Esteve Fernandez, Takagi, Isamu


### PR DESCRIPTION
## Description

Fixes wrongly updated `CHANGELOG.rst` due to manual operation for `package.xml` in [this PR](https://github.com/autowarefoundation/autoware_adapi_msgs/pull/79)

## How was this PR tested?

I double checked the missing procedure with @isamu-takagi. Hopefully this is the right one.

## Notes for reviewers

None.

## Effects on system behavior

None.
