### PR TITLE
feat(autoware_adapi_v1_msgs): add parent field to diag leaf message

### DIFF
--- a/autoware_adapi_v1_msgs/system/msg/DiagLeafStruct.msg
+++ b/autoware_adapi_v1_msgs/system/msg/DiagLeafStruct.msg
@@ -1,1 +1,2 @@
+uint32 parent
 string name


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware_adapi_msgs/pull/92 adds leaf status for raw diag, but the link data for diag leaf was incompatible with some applications, so fix it.

## How was this PR tested?

https://github.com/autowarefoundation/autoware_universe/pull/10846

## Notes for reviewers

None.

## Effects on system behavior

None.
