### PR TITLE
docs: add unit and range documentation to message fields

### DIFF
--- a/autoware_adapi_v1_msgs/manual/msg/PedalsCommand.msg
+++ b/autoware_adapi_v1_msgs/manual/msg/PedalsCommand.msg
@@ -1,3 +1,5 @@
 builtin_interfaces/Time stamp
+# Throttle pedal position. Range: 0.0 to 1.0 (normalized)
 float32 throttle
+# Brake pedal position. Range: 0.0 to 1.0 (normalized)
 float32 brake

--- a/autoware_adapi_v1_msgs/manual/msg/SteeringCommand.msg
+++ b/autoware_adapi_v1_msgs/manual/msg/SteeringCommand.msg
@@ -1,3 +1,5 @@
 builtin_interfaces/Time stamp
+# Steering tire angle [rad]. Positive: left, Negative: right
 float32 steering_tire_angle
+# Steering tire angular velocity [rad/s]
 float32 steering_tire_velocity

--- a/autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
+++ b/autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
@@ -12,7 +12,7 @@ geometry_msgs/Pose pose
 float32 distance
 # Current status (use status constants above)
 uint16 status
-# Behavior type (see PlanningBehavior.msg for valid values)
+# Behavior type (see PlanningBehavior.msg for typical values, any name is available for user extensions)
 string behavior
 # Planning sequence identifier
 string sequence

--- a/autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
+++ b/autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
@@ -6,7 +6,7 @@ uint16 APPROACHING = 1  # Vehicle is approaching the factor
 uint16 STOPPED = 2      # Vehicle has stopped due to the factor
 
 # fields
-# Pose of the velocity factor in map frame
+# Pose of the velocity factor in VelocityFactorArray.header.frame_id
 geometry_msgs/Pose pose
 # Distance to the velocity factor [m]
 float32 distance

--- a/autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
+++ b/autoware_adapi_v1_msgs/planning/msg/VelocityFactor.msg
@@ -2,14 +2,21 @@
 uint16 UNKNOWN = 0
 
 # constants for status
-uint16 APPROACHING = 1
-uint16 STOPPED = 2
+uint16 APPROACHING = 1  # Vehicle is approaching the factor
+uint16 STOPPED = 2      # Vehicle has stopped due to the factor
 
-# variables
+# fields
+# Pose of the velocity factor in map frame
 geometry_msgs/Pose pose
+# Distance to the velocity factor [m]
 float32 distance
+# Current status (use status constants above)
 uint16 status
+# Behavior type (see PlanningBehavior.msg for valid values)
 string behavior
+# Planning sequence identifier
 string sequence
+# Detailed description of the factor
 string detail
+# Cooperation status (optional, max 1 element)
 autoware_adapi_v1_msgs/CooperationStatus[<=1] cooperation


### PR DESCRIPTION
## Description

Add inline comments to message fields to clarify units, ranges, and valid values.

Changes:
- `PedalsCommand.msg`: Document throttle/brake range (0.0-1.0 normalized)
- `SteeringCommand.msg`: Document steering_tire_angle [rad] and velocity [rad/s]
- `VelocityFactor.msg`: Document distance [m] and add field descriptions

Related to https://github.com/autowarefoundation/autoware_adapi_msgs/issues/106

## How was this PR tested?

Message definition changes are documentation-only (comments). No functional changes.

## Notes for reviewers

None.

## Effects on system behavior

None.