### PR TITLE
docs: add documentation to remaining msg/srv fields

### DIFF
--- a/autoware_adapi_v1_msgs/localization/srv/InitializeLocalization.srv
+++ b/autoware_adapi_v1_msgs/localization/srv/InitializeLocalization.srv
@@ -1,7 +1,10 @@
+# Initial pose for localization.
+# Empty array: request auto-initialization using GNSS.
+# Single element: use as initial guess for localization.
 geometry_msgs/PoseWithCovarianceStamped[<=1] pose
 ---
-uint16 ERROR_UNSAFE = 1
-uint16 ERROR_GNSS_SUPPORT = 2
-uint16 ERROR_GNSS = 3
-uint16 ERROR_ESTIMATION = 4
+uint16 ERROR_UNSAFE = 1      # Initialization rejected due to unsafe conditions
+uint16 ERROR_GNSS_SUPPORT = 2  # GNSS-based initialization not supported
+uint16 ERROR_GNSS = 3        # GNSS initialization failed
+uint16 ERROR_ESTIMATION = 4  # Pose estimation failed
 autoware_adapi_v1_msgs/ResponseStatus status

--- a/autoware_adapi_v1_msgs/manual/msg/AccelerationCommand.msg
+++ b/autoware_adapi_v1_msgs/manual/msg/AccelerationCommand.msg
@@ -1,2 +1,3 @@
 builtin_interfaces/Time stamp
+# [m/s^2]. Positive is acceleration, negative is deceleration.
 float32 acceleration

--- a/autoware_adapi_v1_msgs/manual/msg/VelocityCommand.msg
+++ b/autoware_adapi_v1_msgs/manual/msg/VelocityCommand.msg
@@ -1,3 +1,3 @@
 builtin_interfaces/Time stamp
-# [m/s]. Range: >= 0.0
+# [m/s]. Negative value is backward.
 float32 velocity

--- a/autoware_adapi_v1_msgs/manual/msg/VelocityCommand.msg
+++ b/autoware_adapi_v1_msgs/manual/msg/VelocityCommand.msg
@@ -1,2 +1,3 @@
 builtin_interfaces/Time stamp
+# [m/s]. Range: >= 0.0
 float32 velocity

--- a/autoware_adapi_v1_msgs/manual/srv/SelectManualControlMode.srv
+++ b/autoware_adapi_v1_msgs/manual/srv/SelectManualControlMode.srv
@@ -1,3 +1,4 @@
+# Manual control mode to select (e.g., direct control, velocity control)
 autoware_adapi_v1_msgs/ManualControlMode mode
 ---
 autoware_adapi_v1_msgs/ResponseStatus status

--- a/autoware_adapi_v1_msgs/motion/srv/AcceptStart.srv
+++ b/autoware_adapi_v1_msgs/motion/srv/AcceptStart.srv
@@ -1,3 +1,5 @@
+# Accept vehicle start after motion state becomes STARTING.
+# Call this service to confirm that the vehicle should begin moving.
 ---
-uint16 ERROR_NOT_STARTING = 1
+uint16 ERROR_NOT_STARTING = 1  # Vehicle is not in STARTING state
 autoware_adapi_v1_msgs/ResponseStatus status

--- a/autoware_adapi_v1_msgs/operation_mode/srv/ChangeOperationMode.srv
+++ b/autoware_adapi_v1_msgs/operation_mode/srv/ChangeOperationMode.srv
@@ -1,4 +1,7 @@
+# Request to change operation mode.
+# The target mode is implicit from the service name
+# (e.g., /api/operation_mode/change_to_autonomous).
 ---
-uint16 ERROR_NOT_AVAILABLE = 1
-uint16 ERROR_IN_TRANSITION = 2
+uint16 ERROR_NOT_AVAILABLE = 1  # Requested mode is not available
+uint16 ERROR_IN_TRANSITION = 2  # Already transitioning to another mode
 autoware_adapi_v1_msgs/ResponseStatus status

--- a/autoware_adapi_v1_msgs/perception/msg/ObjectClassification.msg
+++ b/autoware_adapi_v1_msgs/perception/msg/ObjectClassification.msg
@@ -1,11 +1,14 @@
-uint8 UNKNOWN=0
-uint8 CAR=1
-uint8 TRUCK=2
-uint8 BUS=3
-uint8 TRAILER = 4
-uint8 MOTORCYCLE = 5
-uint8 BICYCLE = 6
-uint8 PEDESTRIAN = 7
+# Object classification labels
+uint8 UNKNOWN=0     # Unknown or unclassified object
+uint8 CAR=1         # Passenger car
+uint8 TRUCK=2       # Truck or large vehicle
+uint8 BUS=3         # Bus
+uint8 TRAILER = 4   # Trailer
+uint8 MOTORCYCLE = 5  # Motorcycle
+uint8 BICYCLE = 6   # Bicycle
+uint8 PEDESTRIAN = 7  # Pedestrian
 
+# Classification label (one of the constants above)
 uint8 label
+# Classification probability. Range: 0.0 to 1.0
 float64 probability

--- a/autoware_adapi_v1_msgs/perception/msg/ObjectClassification.msg
+++ b/autoware_adapi_v1_msgs/perception/msg/ObjectClassification.msg
@@ -1,8 +1,8 @@
 # Object classification labels
-uint8 UNKNOWN=0     # Unknown or unclassified object
-uint8 CAR=1         # Passenger car
-uint8 TRUCK=2       # Truck or large vehicle
-uint8 BUS=3         # Bus
+uint8 UNKNOWN = 0   # Unknown or unclassified object
+uint8 CAR = 1       # Passenger car
+uint8 TRUCK = 2     # Truck or large vehicle
+uint8 BUS = 3       # Bus
 uint8 TRAILER = 4   # Trailer
 uint8 MOTORCYCLE = 5  # Motorcycle
 uint8 BICYCLE = 6   # Bicycle

--- a/autoware_adapi_v1_msgs/planning/msg/SteeringFactor.msg
+++ b/autoware_adapi_v1_msgs/planning/msg/SteeringFactor.msg
@@ -2,20 +2,38 @@
 uint16 UNKNOWN = 0
 
 # constants for direction
-uint16 LEFT = 1
-uint16 RIGHT = 2
-uint16 STRAIGHT = 3
+uint16 LEFT = 1      # Steering or turning left
+uint16 RIGHT = 2     # Steering or turning right
+uint16 STRAIGHT = 3  # Going straight
 
 # constants for status
-uint16 APPROACHING = 1
-uint16 TURNING = 3
+uint16 APPROACHING = 1  # Approaching the steering point
+uint16 TURNING = 3      # Currently turning/steering
 
-# variables
+# Poses defining the steering segment
+# pose[0]: start pose of the steering action
+# pose[1]: end pose of the steering action
 geometry_msgs/Pose[2] pose
+
+# Distances to the steering segment [m]
+# distance[0]: distance to start pose
+# distance[1]: distance to end pose
 float32[2] distance
+
+# Direction of the steering action (LEFT, RIGHT, or STRAIGHT)
 uint16 direction
+
+# Current status (APPROACHING or TURNING)
 uint16 status
+
+# Behavior type (see PlanningBehavior.msg for typical values, any name is available for user extensions)
 string behavior
+
+# Planning sequence identifier
 string sequence
+
+# Detailed description of the factor
 string detail
+
+# Cooperation status (optional, max 1 element)
 autoware_adapi_v1_msgs/CooperationStatus[<=1] cooperation

--- a/autoware_adapi_v1_msgs/planning/srv/GetCooperationPolicies.srv
+++ b/autoware_adapi_v1_msgs/planning/srv/GetCooperationPolicies.srv
@@ -1,3 +1,5 @@
+# Get the current cooperation policies for planning modules.
 ---
 autoware_adapi_v1_msgs/ResponseStatus status
+# List of current cooperation policies
 autoware_adapi_v1_msgs/CooperationPolicy[] policies

--- a/autoware_adapi_v1_msgs/planning/srv/SetCooperationCommands.srv
+++ b/autoware_adapi_v1_msgs/planning/srv/SetCooperationCommands.srv
@@ -1,3 +1,4 @@
+# List of cooperation commands to apply to planning modules
 autoware_adapi_v1_msgs/CooperationCommand[] commands
 ---
 autoware_adapi_v1_msgs/ResponseStatus status

--- a/autoware_adapi_v1_msgs/planning/srv/SetCooperationPolicies.srv
+++ b/autoware_adapi_v1_msgs/planning/srv/SetCooperationPolicies.srv
@@ -1,3 +1,4 @@
+# List of cooperation policies to set for planning modules
 autoware_adapi_v1_msgs/CooperationPolicy[] policies
 ---
 autoware_adapi_v1_msgs/ResponseStatus status

--- a/autoware_adapi_v1_msgs/routing/srv/SetRoute.srv
+++ b/autoware_adapi_v1_msgs/routing/srv/SetRoute.srv
@@ -1,11 +1,14 @@
 std_msgs/Header header
+# Route planning options (e.g., allow_goal_modification)
 autoware_adapi_v1_msgs/RouteOption option
+# Goal pose in map frame
 geometry_msgs/Pose goal
+# Lanelet segments defining the route path
 autoware_adapi_v1_msgs/RouteSegment[] segments
 ---
-uint16 ERROR_ROUTE_EXISTS = 1 # Deprecated. Use ERROR_INVALID_STATE.
-uint16 ERROR_INVALID_STATE = 1
-uint16 ERROR_PLANNER_UNREADY = 2
-uint16 ERROR_PLANNER_FAILED = 3
-uint16 ERROR_REROUTE_FAILED = 4
+uint16 ERROR_ROUTE_EXISTS = 1  # Deprecated. Use ERROR_INVALID_STATE.
+uint16 ERROR_INVALID_STATE = 1   # Route already exists or invalid state for setting route
+uint16 ERROR_PLANNER_UNREADY = 2  # Route planner is not ready
+uint16 ERROR_PLANNER_FAILED = 3   # Route planning failed
+uint16 ERROR_REROUTE_FAILED = 4   # Reroute operation failed
 autoware_adapi_v1_msgs/ResponseStatus status

--- a/autoware_adapi_v1_msgs/routing/srv/SetRoutePoints.srv
+++ b/autoware_adapi_v1_msgs/routing/srv/SetRoutePoints.srv
@@ -1,11 +1,14 @@
 std_msgs/Header header
+# Route planning options (e.g., allow_goal_modification)
 autoware_adapi_v1_msgs/RouteOption option
+# Goal pose in map frame
 geometry_msgs/Pose goal
+# Intermediate waypoints between current position and goal
 geometry_msgs/Pose[] waypoints
 ---
-uint16 ERROR_ROUTE_EXISTS = 1 # Deprecated. Use ERROR_INVALID_STATE.
-uint16 ERROR_INVALID_STATE = 1
-uint16 ERROR_PLANNER_UNREADY = 2
-uint16 ERROR_PLANNER_FAILED = 3
-uint16 ERROR_REROUTE_FAILED = 4
+uint16 ERROR_ROUTE_EXISTS = 1  # Deprecated. Use ERROR_INVALID_STATE.
+uint16 ERROR_INVALID_STATE = 1   # Route already exists or invalid state for setting route
+uint16 ERROR_PLANNER_UNREADY = 2  # Route planner is not ready
+uint16 ERROR_PLANNER_FAILED = 3   # Route planning failed
+uint16 ERROR_REROUTE_FAILED = 4   # Reroute operation failed
 autoware_adapi_v1_msgs/ResponseStatus status

--- a/autoware_adapi_v1_msgs/system/srv/SendMrmRequest.srv
+++ b/autoware_adapi_v1_msgs/system/srv/SendMrmRequest.srv
@@ -1,3 +1,4 @@
+# MRM (Minimal Risk Maneuver) request to execute for safe vehicle stop
 autoware_adapi_v1_msgs/MrmRequest request
 ---
 autoware_adapi_v1_msgs/ResponseStatus status

--- a/autoware_adapi_v1_msgs/vehicle/msg/VehicleDimensions.msg
+++ b/autoware_adapi_v1_msgs/vehicle/msg/VehicleDimensions.msg
@@ -1,10 +1,20 @@
+# [m]
 float32 wheel_radius
+# [m]
 float32 wheel_width
+# [m]
 float32 wheel_base
+# [m]
 float32 wheel_tread
+# [m]
 float32 front_overhang
+# [m]
 float32 rear_overhang
+# [m]
 float32 left_overhang
+# [m]
 float32 right_overhang
+# [m]
 float32 height
+# Vehicle footprint polygon in vehicle frame
 geometry_msgs/Polygon footprint

--- a/autoware_adapi_v1_msgs/vehicle/msg/VehicleSpecs.msg
+++ b/autoware_adapi_v1_msgs/vehicle/msg/VehicleSpecs.msg
@@ -1,1 +1,2 @@
+# Maximum steering tire angle [rad]. Positive value is left turn.
 float32 max_steering_tire_angle

--- a/autoware_adapi_v1_msgs/vehicle/srv/SetDoorCommand.srv
+++ b/autoware_adapi_v1_msgs/vehicle/srv/SetDoorCommand.srv
@@ -1,3 +1,4 @@
+# List of door commands to execute
 autoware_adapi_v1_msgs/DoorCommand[] doors
 ---
 autoware_adapi_v1_msgs/ResponseStatus status


### PR DESCRIPTION
## Description

- Continuation of https://github.com/autowarefoundation/autoware_adapi_msgs/pull/107

Add unit information, value ranges, and field descriptions to message and service definitions for improved API clarity:

**msg files:**
- VehicleDimensions.msg: Add [m] unit to all dimension fields
- VehicleSpecs.msg: Add [rad] unit to max_steering_tire_angle
- AccelerationCommand.msg: Add [m/s^2] unit
- VelocityCommand.msg: Add [m/s] unit and range
- ObjectClassification.msg: Add label descriptions and probability range [0.0-1.0]
- SteeringFactor.msg: Add pose[2] and distance[2] array element descriptions

**srv files:**
- InitializeLocalization.srv: Add pose description and error code explanations
- AcceptStart.srv: Add service purpose and error code description
- ChangeOperationMode.srv: Add service purpose and error code descriptions
- SetRoute.srv: Add field descriptions and error code explanations
- SetRoutePoints.srv: Add field descriptions and error code explanations
- SetDoorCommand.srv: Add doors field description
- GetCooperationPolicies.srv: Add service purpose and policies description
- SetCooperationCommands.srv: Add commands description
- SetCooperationPolicies.srv: Add policies description
- SelectManualControlMode.srv: Add mode description
- SendMrmRequest.srv: Add request description

## How was this PR tested?

Documentation-only changes. No functional changes to test.

## Notes for reviewers

None.

## Effects on system behavior

None.