### PR TITLE
refactor(autoware_adapi_msgs): add USE_SCOPED_HEADER_INSTALL_DIR

### DIFF
--- a/autoware_adapi_v1_msgs/CMakeLists.txt
+++ b/autoware_adapi_v1_msgs/CMakeLists.txt
@@ -93,4 +93,4 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     unique_identifier_msgs
 )
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/autoware_adapi_version_msgs/CMakeLists.txt
+++ b/autoware_adapi_version_msgs/CMakeLists.txt
@@ -8,4 +8,4 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/InterfaceVersion.srv"
 )
 
-ament_auto_package()
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)


### PR DESCRIPTION
## Description

This PR adds `USE_SCOPED_HEADER_INSTALL_DIR` to existing `ament_auto_package()` calls in `autoware_adapi_msgs`.

Updated packages:
- `autoware_adapi_v1_msgs`
- `autoware_adapi_version_msgs`

## How was this PR tested?

Built the target packages locally:
```bash
colcon build --base-paths ~/autoware_scoped_headers/autoware/src \
  --symlink-install \
  --cmake-args -DCMAKE_BUILD_TYPE=Release \
  --packages-select \
  autoware_adapi_v1_msgs \
  autoware_adapi_version_msgs
```

All packages built successfully.

## Notes for reviewers

This is part of the follow-up work after adding `USE_SCOPED_HEADER_INSTALL_DIR` support to `autoware_cmake`.

## Interface changes

None.

## Effects on system behavior

No functional behavior change. This updates the package macro options for the scoped header installation migration.